### PR TITLE
Update CLAUDE.md and README.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,56 +2,72 @@
 
 ## What is this repo?
 
-Data collection layer for an NCAA tournament bracket analysis app. Uses Claude's computer use API to control a headless browser and scrape ESPN for bracket picks, game results, and betting odds.
+NCAA tournament bracket analysis app. Scores bracket picks, compares players head-to-head, runs scenario simulations (brute-force + Monte Carlo), and presents everything in a Streamlit web UI. Data collected from ESPN and DraftKings.
 
 ## Key things to know
 
-- **Claude computer use beta**: `computer_20251124` with `client.beta.messages.create()` — see `src/agent.py`
-- **Browser**: Playwright Chromium (headless). Actions in `src/browser.py`, agent loop in `src/agent.py`
-- **ESPN group URL**: Configured in `config.yaml` under `espn_group.url`. Currently targets Rebecca's bracket.
+- **Analysis layer**: `core/` contains pure Python scoring, scenario engines, comparisons, and data loading. No Streamlit imports.
+- **Plugin system**: `analyses/` has auto-discovered Streamlit plugins (presentation only — business logic goes in `core/`).
+- **Web UI**: `app.py` is the Streamlit entry point. Loads `AnalysisContext` and renders plugins.
 - **Data contract**: `docs/DATA_CONTRACT.md` defines exact schemas. All data uses team slugs and slot IDs.
-- **Data output**: Single JSON files — `data/tournament.json`, `data/results.json`, `data/odds.json`, `data/entries/player_brackets.json` (all gitignored)
-- **NCAA support**: Deferred. Only ESPN is implemented.
+- **Data files**: `data/tournament.json`, `data/results.json`, `data/odds.json`, `data/entries/player_brackets.json` — tracked in git.
+- **ESPN bracket fetching**: `src/extract_bracket.py` uses Playwright DOM extraction. Requires `ANTHROPIC_API_KEY`.
+- **CI**: Ruff lint + pytest + PR validation on every PR to main.
 
 ## How to run
 
 ```bash
-pip install -r requirements.txt && playwright install chromium
-# Set ANTHROPIC_API_KEY in .env
-python scripts/fetch_brackets.py     # fetch bracket picks
-python scripts/fetch_results.py      # fetch results + odds
-python scripts/run_scheduler.py      # start twice-daily scheduler
+pip install -r requirements.txt
+streamlit run app.py                    # launch web UI
+pytest                                  # run tests
+ruff check .                            # lint
+python scripts/validate_data.py         # validate data integrity
+python scripts/run_scenarios.py         # CLI scenario analysis
+python scripts/fetch_espn_bracket.py    # fetch bracket from ESPN (needs ANTHROPIC_API_KEY)
 ```
 
 ## How to extend
 
-To add a new data source or scraping target:
-1. Create `src/fetch_<thing>.py` following the pattern in `fetch_bracket.py`
-2. Write a detailed prompt telling Claude what to navigate and extract
-3. Call `run_agent(prompt, url, browser)` — it returns Claude's text response
-4. Use `extract_json_from_response()` to parse the JSON
-5. Save with `storage.save_*()` or add a new save function
+To add a new analysis plugin:
+1. Create `analyses/<name>.py` with required attrs: `TITLE`, `DESCRIPTION`, `CATEGORY`, `ORDER`, `ICON`, `render(ctx)`
+2. Put business logic in `core/` — plugins are presentation only
+3. The plugin auto-discovers on app restart
+
+To add a new data source:
+1. Create a script in `scripts/`
+2. Use `src/storage.py` for reading/writing data files
+3. Follow schemas in `docs/DATA_CONTRACT.md`
 
 ## Project structure
 
 ```
-src/agent.py          — Core agent loop (reusable for any web task)
-src/browser.py        — Playwright browser + action execution
-src/fetch_bracket.py  — ESPN bracket extraction
-src/fetch_results.py  — Game results extraction
-src/fetch_odds.py     — Betting odds extraction
-src/models.py         — Prompt schema helpers (aligned with docs/DATA_CONTRACT.md)
-src/storage.py        — JSON file read/write
-scripts/              — CLI entry points + scheduler
-config.yaml           — All configuration
+core/scoring.py        — ESPN scoring (10/20/40/80/160/320 per round)
+core/scenarios.py      — Brute-force + Monte Carlo scenario engines
+core/tournament.py     — Game tree traversal, remaining slots, team paths
+core/comparison.py     — H2H diffs, pick popularity, chalk scores
+core/context.py        — Central data object (loads + caches everything)
+core/loader.py         — Data loading + bracket tree validation
+core/models.py         — Dataclasses (Team, GameSlot, Results, PlayerEntry, etc.)
+core/narrative.py      — Template-based text descriptions
+analyses/              — Auto-discovered Streamlit plugins (presentation only)
+app.py                 — Streamlit web UI entry point
+src/extract_bracket.py — ESPN bracket extraction via Playwright DOM
+src/models.py          — Prompt schema helpers
+src/storage.py         — JSON file read/write
+scripts/               — CLI: validation, scenarios, bracket fetching, CI scripts
+tests/                 — pytest test suite
+docs/DATA_CONTRACT.md  — Data schemas
+config.yaml            — Configuration
+pyproject.toml         — pytest + ruff config
+.github/workflows/     — CI pipeline (lint, test, PR validation, review checklist)
 ```
 
 ## Important constraints
 
-- Requires `ANTHROPIC_API_KEY` environment variable
-- ESPN is a JS SPA — cannot be scraped with simple HTTP requests, must use browser
-- Agent loop has a 30-iteration safety cap (`MAX_ITERATIONS` in `agent.py`)
-- Set `browser.headless: false` in config.yaml to watch the browser during development
+- Requires `ANTHROPIC_API_KEY` environment variable for ESPN bracket fetching (not needed for analysis/UI)
+- ESPN is a JS SPA — bracket fetching uses Playwright DOM extraction
+- CI requires `ruff check` + `pytest` to pass before merge
+- PR descriptions must include 6 required sections (see PR conventions below)
 
 ## PR conventions
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ All data uses **team slugs** (lowercase, underscored: `duke`, `north_carolina`, 
 ## Architecture
 
 ```
+core/                       # Pure Python analysis (no Streamlit imports)
+  scoring.py                # ESPN scoring engine (10/20/40/80/160/320)
+  scenarios.py              # Brute-force + Monte Carlo scenario engines
+  tournament.py             # Game tree traversal, remaining slots, team paths
+  comparison.py             # H2H diffs, pick popularity, chalk scores
+  context.py                # Central data object (loads + caches everything)
+  loader.py                 # Data loading + bracket tree validation
+  models.py                 # Dataclasses (Team, GameSlot, Results, PlayerEntry)
+  narrative.py              # Template-based text descriptions
+
+analyses/                   # Auto-discovered Streamlit plugins (presentation only)
+  leaderboard.py            # Standings and rankings
+  my_bracket.py             # Individual bracket view
+  head_to_head.py           # Player comparison diffs
+  group_picks.py            # Group-wide pick analysis
+  win_probability.py        # Win% dashboard and critical games
+  scenarios_whatif.py        # Game-by-game what-if tool
+  race.py                   # Race to the finish tracker
+
+app.py                      # Streamlit web UI entry point
+
 data/                       # Tournament data (tracked in git)
   tournament.json           # Teams, seeds, regions, bracket tree
   results.json              # Game results keyed by slot_id
@@ -33,6 +54,7 @@ data/                       # Tournament data (tracked in git)
     player_brackets.json    # All player bracket picks
 
 src/
+  extract_bracket.py        # ESPN bracket extraction via Playwright DOM
   models.py                 # Prompt schema helpers
   storage.py                # JSON file read/write
 
@@ -40,11 +62,31 @@ scripts/
   validate_data.py          # Structural + score sanity validation
   verify_points.py          # Team point tally cross-check
   verify_results.py         # Web cross-reference against ESPN
+  run_scenarios.py          # CLI scenario analysis
+  fetch_espn_bracket.py     # Fetch bracket from ESPN group
+  fetch_batch_brackets.py   # Batch fetch multiple brackets
+  validate_pr.py            # PR description validation (used by CI)
+  review_checklist.py       # Diff-aware review checklist (used by CI)
+
+tests/                      # pytest test suite
+  test_scoring.py           # Scoring engine tests
+  test_scenarios.py         # Scenario engine tests
+  test_comparisons.py       # Comparison logic tests
+  test_plugins.py           # Plugin discovery tests
+  test_odds_integration.py  # Odds integration tests
+  test_validate_pr.py       # PR validation tests
+  test_review_checklist.py  # Review checklist tests
+  fixtures/                 # Test data (mini tournament)
 
 docs/
   DATA_CONTRACT.md          # Exact schemas for all data files
 
+.github/
+  workflows/ci.yml          # CI: ruff + pytest + PR validation + review checklist
+  PULL_REQUEST_TEMPLATE.md  # 6-section PR template
+
 config.yaml                 # Data directory and source URLs
+pyproject.toml              # pytest + ruff config
 ```
 
 ## Validation
@@ -63,11 +105,31 @@ python scripts/verify_points.py --team duke
 python scripts/verify_results.py
 ```
 
+## Web UI
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+The app loads `AnalysisContext` (tournament, results, entries) and renders analysis plugins from `analyses/`. Plugins auto-discover — add a new `.py` file to `analyses/` and it appears in the sidebar.
+
+## Testing & CI
+
+```bash
+pytest              # run tests
+ruff check .        # lint
+```
+
+CI runs both on every PR to `main`. Additionally:
+- **PR validation**: hard-fails if any of the 6 required sections are missing from the PR description
+- **Review checklist**: posts an advisory comment based on which files changed
+
 ## Setup
 
 ```bash
 pip install -r requirements.txt
-playwright install chromium   # only needed for verify_results.py
+playwright install chromium   # only needed for ESPN bracket fetching and verify_results.py
 ```
 
 ## Updating Data


### PR DESCRIPTION
## Requirements

CLAUDE.md and README.md were written during the initial data collection phase (PRs #1-2) and never updated as the project evolved. Both docs now contain factual inaccuracies (referencing deleted files, incorrect gitignore claims) and are missing documentation for ~40% of the codebase. Since CLAUDE.md serves as the system prompt for every agent entering this repo, accuracy here directly impacts agent effectiveness.

## Solution

**CLAUDE.md** — Fixed all factual inaccuracies and added missing content:
- "Data collection layer" → "NCAA tournament bracket analysis app" (what it actually is now)
- Replaced references to deleted files (`src/agent.py`, `src/browser.py`, 5 fetch modules) with current files
- "all gitignored" → "tracked in git"
- Replaced deleted script commands with actual commands (`streamlit run app.py`, `pytest`, `ruff check`)
- Added full project structure covering `core/`, `analyses/`, `app.py`, `tests/`, CI
- Added plugin creation and data source extension guides
- PR conventions section preserved unchanged, word for word

**README.md** — Added missing sections:
- Architecture section now includes `core/` (8 modules), `analyses/` (7 plugins), `tests/` (7 test files + fixtures), `app.py`, `.github/`, all scripts
- New "Web UI" section
- New "Testing & CI" section

## Issues & Revisions

- First draft proposed removing existing CLAUDE.md content wholesale — revised after feedback to only fix factual inaccuracies and add missing content, preserving all rules and behavioral guidance
- Had to resolve merge conflicts where our branch had lint fixes on files that main had deleted (agent.py, browser.py, fetch scripts) — accepted main's deletions since those files were intentionally removed in PR #8
- The branch also carries older commits from prior CI work (review checklist, PR validation) — only the latest commit (352e316) is the docs update

## Decisions

- **Fix facts, don't remove context**: Kept the principle that existing useful content stays, only corrected what was factually wrong (deleted file references, incorrect claims)
- **PR conventions untouched**: The behavioral rules section was preserved byte-for-byte since those are rules, not facts about the codebase
- **README architecture expanded inline**: Rather than creating a separate architecture doc, expanded the existing Architecture section to cover all directories — keeps everything in one place

## Testing

- `ruff check .` — all checks passed
- Verified no references to deleted files remain in either doc
- Verified all commands in "How to run" reference scripts that exist on main
- PR conventions section confirmed identical to original

## Scope

Scope was exactly as planned: two files updated (CLAUDE.md, README.md), no code changes. No scope creep. The branch carries older CI commits from prior work but the docs update is isolated to the latest commit.

https://claude.ai/code/session_018vsXy3ToN1YcYexnm5BqV4