### PR TITLE
Address PR #24 review gaps and add bulk swap finder (WI-4)

### DIFF
--- a/core/comparison.py
+++ b/core/comparison.py
@@ -138,6 +138,91 @@ def compare_counterfactual(
     }
 
 
+def find_best_swaps(
+    entries: list[PlayerEntry],
+    player_name: str,
+    tournament: TournamentStructure,
+    results: Results,
+    odds: dict | None = None,
+    max_swaps: int = 10,
+) -> list[dict]:
+    """Find the single-pick swaps that most improve a player's win probability.
+
+    For each pending game, tries swapping to the alternate team and measures
+    the win probability delta. Returns top swaps ranked by delta descending.
+
+    Returns list of dicts:
+        slot_id, round, old_team, new_team, original_pct, new_pct, delta
+    """
+    from core.scenarios import run_scenarios
+    from core.scoring import score_entry
+    from core.tournament import get_remaining_games
+
+    entry = next(
+        (e for e in entries if e.player_name == player_name),
+        None,
+    )
+    if entry is None:
+        raise ValueError(f"Player '{player_name}' not found in entries")
+
+    # Get the player's scored entry to find pending picks
+    scored = score_entry(entry, tournament, results)
+
+    # Get remaining games with their participants
+    remaining = get_remaining_games(tournament, results)
+    remaining_by_slot = {g["slot_id"]: g for g in remaining}
+
+    # Run original scenarios once (reused for all comparisons)
+    original_sr = run_scenarios(entries, tournament, results, odds=odds)
+    original_total = original_sr.total_scenarios
+    original_pct = (
+        original_sr.win_counts.get(player_name, 0) / original_total * 100
+        if original_total > 0
+        else 0.0
+    )
+
+    swaps = []
+    for slot_id in scored.pending_picks:
+        game = remaining_by_slot.get(slot_id)
+        if not game or not game["team_a"] or not game["team_b"]:
+            continue
+
+        current_pick = entry.picks.get(slot_id)
+        possible_teams = [game["team_a"], game["team_b"]]
+
+        for new_team in possible_teams:
+            if new_team == current_pick:
+                continue
+
+            cf_entry = counterfactual_entry(
+                entry, {slot_id: new_team}, tournament, propagate=True,
+            )
+            cf_entries = [
+                cf_entry if e.player_name == player_name else e
+                for e in entries
+            ]
+            cf_sr = run_scenarios(cf_entries, tournament, results, odds=odds)
+            cf_total = cf_sr.total_scenarios
+            cf_pct = (
+                cf_sr.win_counts.get(player_name, 0) / cf_total * 100
+                if cf_total > 0
+                else 0.0
+            )
+
+            swaps.append({
+                "slot_id": slot_id,
+                "round": game["round"],
+                "old_team": current_pick,
+                "new_team": new_team,
+                "original_pct": original_pct,
+                "new_pct": cf_pct,
+                "delta": cf_pct - original_pct,
+            })
+
+    swaps.sort(key=lambda s: -s["delta"])
+    return swaps[:max_swaps]
+
+
 # --- Head to Head ---
 
 

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -15,6 +15,7 @@ from core.comparison import (
     compare_counterfactual,
     contrarian_picks,
     counterfactual_entry,
+    find_best_swaps,
     group_chalk_score,
     head_to_head,
     pick_popularity,
@@ -359,4 +360,57 @@ class TestCompareCounterfactual:
                 entries, "NonexistentPlayer",
                 {"r2_west_1": "alabama"},
                 tournament, results,
+            )
+
+
+class TestFindBestSwaps:
+    """Tests for find_best_swaps() — WI-4."""
+
+    def test_returns_ranked_list(self, tournament, results, entries):
+        """Should return swaps sorted by delta descending."""
+        swaps = find_best_swaps(entries, "Alice", tournament, results)
+
+        assert isinstance(swaps, list)
+        assert len(swaps) > 0
+        # Sorted by delta descending
+        for i in range(len(swaps) - 1):
+            assert swaps[i]["delta"] >= swaps[i + 1]["delta"]
+
+    def test_swap_has_required_keys(self, tournament, results, entries):
+        """Each swap dict should contain all required keys."""
+        swaps = find_best_swaps(entries, "Alice", tournament, results)
+        required = {"slot_id", "round", "old_team", "new_team",
+                     "original_pct", "new_pct", "delta"}
+
+        for swap in swaps:
+            assert required.issubset(swap.keys())
+
+    def test_only_pending_slots(self, tournament, results, entries):
+        """Swaps should only be for pending (unplayed) slots."""
+        swaps = find_best_swaps(entries, "Alice", tournament, results)
+        completed = set(results.results.keys())
+
+        for swap in swaps:
+            assert swap["slot_id"] not in completed
+
+    def test_no_swap_to_same_team(self, tournament, results, entries):
+        """Should never suggest swapping to the team already picked."""
+        alice = _get_entry(entries, "Alice")
+        swaps = find_best_swaps(entries, "Alice", tournament, results)
+
+        for swap in swaps:
+            assert swap["new_team"] != alice.picks[swap["slot_id"]]
+
+    def test_max_swaps_respected(self, tournament, results, entries):
+        """Should return at most max_swaps results."""
+        swaps = find_best_swaps(
+            entries, "Alice", tournament, results, max_swaps=1,
+        )
+        assert len(swaps) <= 1
+
+    def test_unknown_player_raises(self, tournament, results, entries):
+        """Should raise ValueError for unknown player."""
+        with pytest.raises(ValueError, match="not found in entries"):
+            find_best_swaps(
+                entries, "NonexistentPlayer", tournament, results,
             )


### PR DESCRIPTION
## Requirements

Follow-up to PR #24 (merged). Address self-review gaps and implement WI-4 (#21) bulk swap finder.

## Solution

**Review gap fixes** (commit 1):
- Added `ValueError` when `propagate=True` but `tournament=None`
- Added descriptive `ValueError` when player not found in `compare_counterfactual`
- Added multi-hop cascade test (R1 → R2 → Championship)
- Added multiple simultaneous overrides test (round-ordered processing)
- Replaced weak `test_scoreable` with `test_scoreable_and_score_differs` (asserts +10 pts)
- Added `test_unknown_player_raises` for `compare_counterfactual`
- Added blank line before Head to Head section

**WI-4 bulk swap finder** (commit 2):
- `find_best_swaps()` in `core/comparison.py` — iterates pending slots, tries each alternate team with propagation, ranks by win probability delta
- 6 tests: ranked output, required keys, pending-only slots, no same-team swaps, max_swaps cap, unknown player error

## Issues & Revisions

- PR #24 was merged before these commits were pushed. Cherry-picked both commits onto fresh branch off main.
- WI-4 reuses `counterfactual_entry()` with `propagate=True` and `run_scenarios()` — no new engine code needed.

## Decisions

- `find_best_swaps` runs original scenarios once, then one counterfactual run per possible swap — efficient for small remaining game counts (3 games = 6 swaps max).
- Uses `ScoredEntry.pending_picks` to identify swappable slots, `get_remaining_games()` for possible teams.

## Testing

- Tests: 16 → 36 in `test_comparisons.py`, 121 total passing
- Lint clean (`ruff check .`)
- All acceptance criteria from issues #17, #19, #20 now covered (multi-hop cascade, multiple overrides, defensive errors)

## Scope

Closes #21 (WI-4). Addresses all gaps from the self-review on PR #24.

https://claude.ai/code/session_013m1JaCExHSEv2bjdW75ruA