### PR TITLE
fix(process): close 4 process hygiene gaps identified in guidelines audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: ruff check .
       - name: Test
         run: pytest
+      - name: Validate data files
+        run: python scripts/validate_data.py
 
   validate-pr:
     if: github.event_name == 'pull_request'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,6 @@ streamlit run app.py                    # launch web UI
 pytest                                  # run tests
 ruff check .                            # lint
 python scripts/validate_data.py         # validate data integrity
-python scripts/run_scenarios.py         # CLI scenario analysis
 ```
 
 ## How to extend

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All tournament data lives in `data/` and is tracked in git. See `docs/DATA_CONTR
 | `data/tournament.json` | 64 teams, 63 slots, bracket tree | 64 teams |
 | `data/results.json` | Completed game results with scores | 60 games (through Elite 8) |
 | `data/odds.json` | DraftKings betting lines by round | 58 games (R1 + R32 + S16 + FF) |
-| `data/entries/player_brackets.json` | Player bracket picks | Evan (63 picks), Rebecca (63 picks via ESPN) |
+| `data/entries/player_brackets.json` | Player bracket picks | 7 players (Evan, Rebecca, Elizabeth, Hugh, tvenie, scrapr + 1 more) |
 
 ### Data Sources
 
@@ -33,7 +33,18 @@ core/                       # Pure Python analysis (no Streamlit imports)
   context.py                # Central data object (loads + caches everything)
   loader.py                 # Data loading + bracket tree validation
   models.py                 # Dataclasses (Team, GameSlot, Results, PlayerEntry)
-  narrative.py              # Template-based text descriptions
+  narrative.py              # Template-based text descriptions (fallback)
+  metrics.py                # Win equity, separation, must-have outcomes
+  awards.py                 # End-of-tournament superlatives
+  recap.py                  # Round recap generation
+  superlatives.py           # Player distinction logic
+  ai/                       # Claude integration (Anthropic tool-use)
+    client.py               # Anthropic client singleton
+    tools.py                # Tool schemas + adapters wrapping core/ functions
+    agent.py                # Claude tool-use loop: prompt → tool_use → execute
+    lenses.py               # System prompts + model config per output mode
+    evidence.py             # Evidence packet capture + audit logging
+    cache.py                # Content cache keyed on (lens, viewer, data_hash)
 
 analyses/                   # Auto-discovered Streamlit plugins (presentation only)
   leaderboard.py            # Standings and rankings
@@ -41,8 +52,15 @@ analyses/                   # Auto-discovered Streamlit plugins (presentation on
   head_to_head.py           # Player comparison diffs
   group_picks.py            # Group-wide pick analysis
   win_probability.py        # Win% dashboard and critical games
-  scenarios_whatif.py        # Game-by-game what-if tool
+  scenarios_whatif.py       # Game-by-game what-if tool
   race.py                   # Race to the finish tracker
+  my_position.py            # Win equity, separation, must-have outcomes, danger games
+  threats.py                # Who you need to beat and how likely you are to do it
+  rooting_guide.py          # What to root for, what to fear, what doesn't matter
+  pool_exposure.py          # Where the pool is crowded and where you're alone
+  round_recap.py            # Round results, upsets, and standings impact
+  superlatives.py           # End-of-tournament awards and distinctions
+  ask_claude.py             # Freeform AI chat about brackets, scenarios, and odds
 
 app.py                      # Streamlit web UI entry point
 
@@ -51,7 +69,7 @@ data/                       # Tournament data (tracked in git)
   results.json              # Game results keyed by slot_id
   odds.json                 # DraftKings lines by round
   entries/
-    player_brackets.json    # All player bracket picks
+    player_brackets.json    # All player bracket picks (7 players)
 
 src/
   extract_bracket.py        # ESPN bracket extraction via Playwright DOM
@@ -62,7 +80,7 @@ scripts/
   validate_data.py          # Structural + score sanity validation
   verify_points.py          # Team point tally cross-check
   verify_results.py         # Web cross-reference against ESPN
-  run_scenarios.py          # CLI scenario analysis
+  generate_content.py       # Pre-generate AI content to warm the cache
   fetch_espn_bracket.py     # Fetch bracket from ESPN group
   fetch_batch_brackets.py   # Batch fetch multiple brackets
   validate_pr.py            # PR description validation (used by CI)
@@ -74,16 +92,22 @@ tests/                      # pytest test suite
   test_comparisons.py       # Comparison logic tests
   test_plugins.py           # Plugin discovery tests
   test_odds_integration.py  # Odds integration tests
+  test_ai_agent.py          # AI agent loop tests
+  test_ai_tools.py          # AI tool schema tests
+  test_ai_cache.py          # Content cache tests
+  test_ai_evidence.py       # Evidence capture tests
+  test_ai_context.py        # AI context integration tests
   test_validate_pr.py       # PR validation tests
   test_review_checklist.py  # Review checklist tests
   fixtures/                 # Test data (mini tournament)
 
 docs/
   DATA_CONTRACT.md          # Exact schemas for all data files
+  decisions/                # Architecture Decision Records (ADRs)
 
 .github/
   workflows/ci.yml          # CI: ruff + pytest + PR validation + review checklist
-  PULL_REQUEST_TEMPLATE.md  # 6-section PR template
+  PULL_REQUEST_TEMPLATE.md  # 7-section PR template (incl. Squash Commit)
 
 config.yaml                 # Data directory and source URLs
 pyproject.toml              # pytest + ruff config
@@ -122,7 +146,7 @@ ruff check .        # lint
 ```
 
 CI runs both on every PR to `main`. Additionally:
-- **PR validation**: hard-fails if any of the 6 required sections are missing from the PR description
+- **PR validation**: hard-fails if any of the 7 required sections are missing from the PR description
 - **Review checklist**: posts an advisory comment based on which files changed
 
 ## Setup

--- a/scripts/review_checklist.py
+++ b/scripts/review_checklist.py
@@ -33,6 +33,11 @@ RULES: list[tuple[str, callable, str]] = [
         "Scoring logic changed — did you update `tests/test_scoring.py`?",
     ),
     (
+        "ai-tests",
+        lambda f: f.startswith("core/ai/") and f.endswith(".py"),
+        "AI layer changed — did you update or add tests in `tests/test_ai_*.py`?",
+    ),
+    (
         "plugin-attrs",
         lambda f: f.startswith("analyses/") and f.endswith(".py") and f != "analyses/__init__.py",
         "Analysis plugin changed — does it have all required attrs"

--- a/tests/test_review_checklist.py
+++ b/tests/test_review_checklist.py
@@ -42,6 +42,10 @@ class TestGenerateChecklist:
         test_items = [i for i in items if "update or add tests" in i]
         assert len(test_items) == 1
 
+    def test_ai_layer_change_triggers_ai_test_reminder(self):
+        items = generate_checklist(["core/ai/agent.py"])
+        assert any("test_ai_" in item for item in items)
+
     def test_empty_input(self):
         items = generate_checklist([])
         assert items == []


### PR DESCRIPTION
## Requirements

Process audit identified 4 gaps in the guidelines/CI/documentation layer:
- P0: CLAUDE.md references `scripts/run_scenarios.py` which doesn&#39;t exist
- P1: README architecture section is ~6 weeks stale (7 plugins listed, now 14; no core/ai/; wrong scripts)
- P2: review_checklist.py has no rule for core/ai/ changes despite 6 AI modules and 5 AI test files
- P3: validate_data.py has never been in CI despite being the primary data integrity gate

## Solution

Four targeted fixes, all mechanical — no logic changes, no new features.

**CLAUDE.md**: Removed one stale line (`python scripts/run_scenarios.py`).

**README.md**: Updated architecture section to reflect current main:
- analyses/: 7 plugins → 14 (added my_position, threats, rooting_guide, pool_exposure, round_recap, superlatives, ask_claude)
- core/: added ai/ submodule block with all 6 modules; added metrics, awards, recap, superlatives
- scripts/: removed run_scenarios.py; added generate_content.py
- tests/: added 5 AI test files
- docs/: added decisions/ ADR directory
- PR template note and CI section: &#34;6 sections&#34; → &#34;7 sections&#34;
- Data table: &#34;Evan + Rebecca&#34; → &#34;7 players&#34;

**review_checklist.py**: Added `ai-tests` rule — `core/ai/*.py` changes now trigger &#34;AI layer changed — did you update tests/test_ai_*.py?&#34; The existing `core-tests` rule already fires for core/ai/ but doesn&#39;t name the specific files. Added corresponding test (9/9 passing).

**.github/workflows/ci.yml**: Added `python scripts/validate_data.py` step to lint-and-test job after pytest. Runs against real data/ (tracked in git). Confirmed locally: VALIDATION PASSED, 7 players, 62 results.

## Issues &amp; Revisions

The initial evaluation (opening PR #78) was against a stale local branch — main had already advanced through PRs #60–#77 and fixed the original CLAUDE.md regression. PR #78 was closed immediately as superseded. This PR is the corrected, on-main-baseline version of the audit fixes.

One finding not addressed here: the `docs/session-notes/` policy. `docs/session-notes/2026-04-07-session-review.md` exists on main and it&#39;s unclear whether it&#39;s intentional (audit trail) or accidental. Left for separate discussion rather than guessing.

## Decisions

- **validate_data.py uses real data/ not fixtures**: The data files are tracked in git and always present in CI checkout. Using fixtures would require either modifying the script (adding a CLI arg) or maintaining a separate copy — unnecessary complexity when the real data is already correct and checked in.
- **ai-tests rule alongside core-tests**: The generic core-tests rule fires for core/ai/ but doesn&#39;t direct attention to test_ai_*.py specifically. Both rules can fire simultaneously — the general reminder and the specific one. No deduplication issue because they have different rule names.
- **One commit, one PR**: All 4 fixes are small and related (process hygiene). Bundling avoids 4 trivial PRs while keeping the change atomic within its concern.

## Testing

- `python scripts/validate_data.py` → VALIDATION PASSED (7 players, 62 results)
- `python -m pytest tests/test_review_checklist.py tests/test_validate_pr.py tests/test_scoring.py -v` → 28/28 passed
- Verified every file listed in the updated README exists on main via `ls`
- Verified `run_scenarios.py` does NOT exist in scripts/ on main

## Scope

No scope creep. Strictly limited to the 4 gaps identified in the audit (P0–P3).

Two items explicitly deferred to separate discussions:
- **P4 — session-notes policy**: `docs/session-notes/2026-04-07-session-review.md` exists on main and it's unclear whether it's intentional (dev audit trail) or accidental. Needs owner decision before touching.
- **P5 — ADR 007 (evidence/cache design)**: The AI evidence capture + content cache is a significant architectural decision not yet documented as an ADR. Deferred as optional — ADR 006 covers tool-use integration at a sufficient level for now.

Commit message convention enforcement was also considered and intentionally left as honor-system — adding CI enforcement (e.g. commitlint) would add tooling friction with minimal benefit given the existing commit quality.

## Squash Commit

fix(process): close 4 process hygiene gaps identified in guidelines audit

Removes stale run_scenarios.py reference from CLAUDE.md; brings README architecture section current (7→14 plugins, adds core/ai/, correct scripts list); adds core/ai/ checklist rule to review_checklist.py with test; adds validate_data.py step to CI lint-and-test job.