### PR TITLE
Add Time Machine: view tournament state at any historical round

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import yaml
 
 from analyses import discover_plugins, get_plugins_by_category
 from core.context import AnalysisContext
+from core.scoring import ROUND_NAMES
 
 
 def _load_config() -> dict:
@@ -27,18 +28,18 @@ st.set_page_config(
 
 
 @st.cache_data(ttl=60)
-def load_context() -> AnalysisContext:
-    """Load all data and pre-compute. Cached for 60 seconds."""
-    return AnalysisContext(data_dir="data")
+def load_context(view_as_of_round: int | None = None) -> AnalysisContext:
+    """Load all data and pre-compute. Cached for 60 seconds per round view."""
+    return AnalysisContext(data_dir="data", view_as_of_round=view_as_of_round)
 
 
 def main():
     config = _load_config()
 
-    # Load data
+    # Load full (live) data — used to determine available rounds and as default view
     try:
-        ctx = load_context()
-        ctx.configure_ai(config.get("ai", {}) or {})
+        full_ctx = load_context()
+        full_ctx.configure_ai(config.get("ai", {}) or {})
     except FileNotFoundError as e:
         st.error(f"Data file not found: {e}")
         st.info("Make sure data files exist in the `data/` directory.")
@@ -51,10 +52,18 @@ def main():
     plugins = discover_plugins()
     plugins_by_cat = get_plugins_by_category(plugins)
 
+    # Determine which rounds have completed games (for Time Machine options)
+    completed_rounds = sorted({
+        full_ctx.tournament.slots[sid].round
+        for sid in full_ctx.results.results
+        if sid in full_ctx.tournament.slots
+    })
+
     # --- Sidebar navigation ---
+    view_round: int | None = None
     with st.sidebar:
         st.title("\U0001f3c0 Bracket Analysis")
-        st.caption(f"{ctx.tournament.year} NCAA Tournament")
+        st.caption(f"{full_ctx.tournament.year} NCAA Tournament")
 
         # Refresh button
         if st.button("Refresh Data", use_container_width=True):
@@ -65,7 +74,7 @@ def main():
 
         # Global "Viewing as" player selector
         my_player_name = config.get("app", {}).get("my_player_name", "")
-        player_names = ctx.player_names()
+        player_names = full_ctx.player_names()
         default_index = 0
         if my_player_name and my_player_name in player_names:
             default_index = player_names.index(my_player_name)
@@ -89,6 +98,30 @@ def main():
             "Navigation",
             list(page_options.keys()),
             label_visibility="collapsed",
+        )
+
+        # Time Machine — only shown when there are completed rounds
+        if completed_rounds:
+            st.divider()
+            st.caption("Time Machine")
+            round_labels: dict[str, int | None] = {"Current": None}
+            round_labels.update({f"After {ROUND_NAMES[r]}": r for r in completed_rounds})
+            time_label = st.selectbox(
+                "View as of...",
+                list(round_labels.keys()),
+                index=0,
+                label_visibility="collapsed",
+            )
+            view_round = round_labels[time_label]
+
+    # Load context for the selected view (cached separately per round)
+    ctx = load_context(view_round) if view_round is not None else full_ctx
+
+    # Historical mode banner
+    if view_round is not None:
+        st.info(
+            f"Viewing tournament after **{ROUND_NAMES[view_round]}** — "
+            f"{ctx.results.completed_count()} of {len(ctx.tournament.slots)} games completed."
         )
 
     # --- Main content area ---

--- a/core/context.py
+++ b/core/context.py
@@ -46,14 +46,28 @@ class AnalysisContext:
     so plugins don't need to re-derive common information.
     """
 
-    def __init__(self, data_dir: str | Path = "data"):
+    def __init__(self, data_dir: str | Path = "data", view_as_of_round: int | None = None):
         data_dir = Path(data_dir)
 
         # Load raw data
         self.tournament: TournamentStructure = load_tournament(
             data_dir / "tournament.json"
         )
-        self.results: Results = load_results(data_dir / "results.json")
+        raw_results = load_results(data_dir / "results.json")
+
+        # Optionally filter results to a historical round snapshot
+        if view_as_of_round is not None:
+            filtered = {
+                slot_id: result
+                for slot_id, result in raw_results.results.items()
+                if (slot := self.tournament.slots.get(slot_id)) and slot.round <= view_as_of_round
+            }
+            self.results = Results(last_updated=raw_results.last_updated, results=filtered)
+        else:
+            self.results = raw_results
+
+        self.view_round: int | None = view_as_of_round  # None = live/current
+
         self.entries: list[PlayerEntry] = load_entries(
             data_dir / "entries" / "player_brackets.json"
         )

--- a/tests/test_time_machine.py
+++ b/tests/test_time_machine.py
@@ -1,0 +1,72 @@
+"""Tests for AnalysisContext view_as_of_round (Time Machine) filtering."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.context import AnalysisContext
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def full_ctx():
+    """Full context with all fixture results (4 R1 + 1 R2 game)."""
+    return AnalysisContext(data_dir=FIXTURES)
+
+
+@pytest.fixture
+def r1_ctx():
+    """Context filtered to after Round 1 only."""
+    return AnalysisContext(data_dir=FIXTURES, view_as_of_round=1)
+
+
+class TestViewAsOfRound:
+    def test_no_filter_returns_all_results(self, full_ctx):
+        """Default (no filter) returns all completed games."""
+        assert full_ctx.results.completed_count() == 5  # 4 R1 + 1 R2
+
+    def test_filter_to_round_1_excludes_r2(self, r1_ctx):
+        """Filtering to round 1 drops the R2 game."""
+        assert r1_ctx.results.completed_count() == 4
+
+    def test_filter_to_round_1_only_has_r1_slots(self, r1_ctx):
+        """All remaining results must be round-1 slots."""
+        for slot_id in r1_ctx.results.results:
+            slot = r1_ctx.tournament.slots.get(slot_id)
+            assert slot is not None
+            assert slot.round == 1
+
+    def test_filter_to_round_2_returns_all(self, full_ctx):
+        """Filtering to round 2 when only R1+R2 exist returns all results."""
+        ctx = AnalysisContext(data_dir=FIXTURES, view_as_of_round=2)
+        assert ctx.results.completed_count() == 5
+
+    def test_view_round_attribute_set(self, r1_ctx, full_ctx):
+        """view_round is set correctly on the context."""
+        assert r1_ctx.view_round == 1
+        assert full_ctx.view_round is None
+
+    def test_current_round_reflects_filter(self, r1_ctx, full_ctx):
+        """current_round() should reflect the filtered state."""
+        assert r1_ctx.current_round() == 1
+        assert full_ctx.current_round() == 2
+
+    def test_alive_teams_reflect_filter(self, r1_ctx, full_ctx):
+        """Alive teams differ — teams eliminated in R1 show as alive pre-filter."""
+        # In the full context someone lost in R2; in R1 view they're still "alive"
+        r1_alive = r1_ctx.alive_teams
+        full_alive = full_ctx.alive_teams
+        # R1 view must have >= teams alive than full (no R2 eliminations yet)
+        assert len(r1_alive) >= len(full_alive)
+
+    def test_leaderboard_reflects_filter(self, r1_ctx, full_ctx):
+        """Leaderboard totals are lower after filtering to R1 (R2 points excluded)."""
+        r1_total = r1_ctx.leaderboard["Total"].sum()
+        full_total = full_ctx.leaderboard["Total"].sum()
+        assert r1_total <= full_total


### PR DESCRIPTION
## Requirements

The tournament is over and the app only shows final state. Users wanted the ability to rewind to the start/end of any round and have the app update as if that were the current moment — standings, leaderboard, alive teams, scoring, all views.

## Solution

Added a "Time Machine" selectbox to the sidebar in `app.py`. Selecting "After Round of 64", "After Sweet 16", etc. filters `results.results` to only include games from rounds ≤ N before `AnalysisContext` pre-computes everything. Since all downstream logic (leaderboard, scoring, alive teams, `current_round()`) derives from that dict, every plugin automatically reflects the historical snapshot with no plugin changes.

- `core/context.py`: `AnalysisContext.__init__` gains `view_as_of_round: int | None = None`. When set, filters results before pre-compute. Stores `self.view_round` for plugins to optionally read.
- `app.py`: Loads full context to discover completed rounds dynamically, renders a selectbox with round options, shows an info banner in historical mode, passes the selected round to a separately-cached `load_context(view_as_of_round)` call.
- `tests/test_time_machine.py`: 8 new tests covering result filtering, round attribute, current_round(), alive teams, and leaderboard totals across the historical filter boundary.

## Issues & Revisions

- First instinct was to add a method like `ctx.filter_to_round()` that returned a new context, but that would require duplicating the pre-compute logic. Passing `view_as_of_round` to the constructor is cleaner — filtering happens before any derivation, so nothing downstream needs to know.
- Streamlit's `@st.cache_data` automatically uses function arguments as cache keys, so `load_context(round=3)` and `load_context(round=None)` are cached independently — no manual cache-keying needed.
- Rebased onto main after the PR was opened — main had added `_load_config()`, `configure_ai()`, and a "Viewing as" player selector since the branch was cut. Resolved by keeping `config = _load_config()` from main, using `full_ctx = load_context()` from our branch, and wiring `full_ctx.configure_ai(...)`. Also fixed a stale `ctx.player_names()` reference → `full_ctx.player_names()`.

## Decisions

- **Filter at construction time, not render time**: Filtering inside `AnalysisContext.__init__` means all 7 analysis plugins work historically for free. Filtering at render time would require every plugin to be aware of the time travel state.
- **`Results(last_updated, results)` constructor reuse**: The existing dataclass already supports any subset of game results — no schema changes needed.
- **Selectbox over slider**: Round names ("Sweet 16", "Elite 8") are more meaningful to users than round numbers.
- **Dynamic round discovery**: Only shows rounds that have data, so the UI degrades gracefully mid-tournament or before any games are played.
- **No ADR**: This is a UI feature addition with no architectural change. The filtering pattern is a natural extension of the existing data-derivation model.

## Testing

- 8 new tests in `tests/test_time_machine.py`, all passing.
- Tests cover: result count after filtering, slot round validation, `view_round` attribute, `current_round()` output, alive team counts, leaderboard totals.
- Syntax validated: `python -m py_compile core/context.py app.py` passes.
- Manual verification path: run `streamlit run app.py`, select "After Round of 64" → leaderboard shows R1-only points, 32 alive teams, current_round = 1; select "Current" → full final standings restored; banner appears only in historical mode.

## Scope

No scope creep. The feature is exactly what was requested: rewind to end-of-round checkpoints with full app fidelity. "Start of round N" is equivalent to "after round N-1" so no separate concept needed. Per-game granularity was not requested and not built.

## Squash Commit

```
feat(app): add Time Machine sidebar to view tournament state at any historical round

Adds a "Time Machine" selectbox to the Streamlit sidebar. Selecting "After
Round of 64", "After Sweet 16", etc. filters AnalysisContext.results to games
from rounds ≤ N before pre-computing leaderboard/scores/alive_teams, so all
analysis plugins automatically reflect the historical snapshot.

- core/context.py: view_as_of_round param + view_round attribute
- app.py: Time Machine selectbox, historical banner, cached per-round context
- tests/test_time_machine.py: 8 tests (8 passing)
```

https://claude.ai/code/session_0155r7LT17ryLgTJAuANZmQD